### PR TITLE
Access properties of falsy objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,13 +50,13 @@ function selectn(query) {
    */
 
   function accessor(object) {
-    var ref = object || (1, eval)('this');
+    var ref = (object != null) ? object : (1, eval)('this');
     var len = parts.length;
     var idx = 0;
 
     // iteratively save each segment's reference
     for (; idx < len; idx += 1) {
-      if (ref) ref = ref[parts[idx]];
+      if (ref != null) ref = ref[parts[idx]];
     }
 
     return ref;

--- a/test/index.js
+++ b/test/index.js
@@ -97,4 +97,9 @@ describe('selectn()', function(){
     assert(byString === byArray);
   });
 
+  it('accesses properties of falsy objects', function() {
+    assert(select('foo.toString', { foo: false }) === Boolean.prototype.toString);
+    assert(select('toFixed', 0) === Number.prototype.toFixed);
+  });
+
 });


### PR DESCRIPTION
In JavaScript `null` and `undefined` are the only values that cause errors on property access. It is perfectly fine to do `true.toString()` or `0..toFixed()`.

This PR changes the behavior to support falsy primitive values. It uses `== null` check to catch both `null` and `undefined` in one piece.