### PR TITLE
Accept array of properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ module.exports = selectn;
  *
  *      contacts.map(selectn('name.first'));
  *
- * @param  {String} query
- * dot/bracket-notation query string
+ * @param  {String | Array} query
+ * dot/bracket-notation query string or array of properties
  *
  * @param  {Object} object
  * object to access
@@ -28,9 +28,14 @@ module.exports = selectn;
 function selectn(query) {
   var parts;
 
-  // normalize query to `.property` access (i.e. `a.b[0]` becomes `a.b.0`)
-  query = query.replace(/\[(\d+)\]/g, '.$1');
-  parts = query.split('.');
+  if (Array.isArray(query)) {
+    parts = query;
+  }
+  else {
+    // normalize query to `.property` access (i.e. `a.b[0]` becomes `a.b.0`)
+    query = query.replace(/\[(\d+)\]/g, '.$1');
+    parts = query.split('.');
+  }
 
   /**
    * Accessor function that accepts an object to be queried

--- a/test/index.js
+++ b/test/index.js
@@ -86,4 +86,15 @@ describe('selectn()', function(){
     assert(select('stats.temperature-today', data) === 40);
   });
 
+  it('accepts property array', function() {
+    var ndarray = [[8, 1, 6],
+                   [3, 5, 7],
+                   [4, 9, 2]];
+
+    var byString = select('1.2', ndarray);
+    var byArray = select([1, 2], ndarray);
+
+    assert(byString === byArray);
+  });
+
 });


### PR DESCRIPTION
It would be very useful if `selectn` could accept `path` directly as an array.

For multi-dimensional arrays, it would save users from needless concatenating.

```js
select((n - 1 - i) + '.' + (j + 1), ndarray) // ⟹ select([n - 1 - i, j + 1], ndarray);
```